### PR TITLE
fix: gvm-installer zsh incompatible use of ==

### DIFF
--- a/binscripts/gvm-installer
+++ b/binscripts/gvm-installer
@@ -86,7 +86,7 @@ then
   git clone --quiet "$SRC_REPO" "$GVM_DEST/$GVM_NAME" 2> /dev/null ||
 	  display_error "Failed to clone from $SRC_REPO into $GVM_DEST/$GVM_NAME"
 else
-  if [[ $GVM_DEST == *"$GIT_ROOT"* ]]
+  if [[ $GVM_DEST = *"$GIT_ROOT"* ]]
   then
     ln -s "$GIT_ROOT" "$GVM_DEST"
   else
@@ -111,12 +111,12 @@ if [ -z "$GVM_NO_UPDATE_PROFILE" ] ; then
   if [ -f "$HOME/.zshrc" ]; then
     update_profile "$HOME/.zshrc"
   fi
-  if [ "$(uname)" == "Linux" ]; then
+  if [ "$(uname)" = "Linux" ]; then
     update_profile "$HOME/.bashrc" || update_profile "$HOME/.bash_profile"
-  elif [ "$(uname)" == "Darwin" ]; then
+  elif [ "$(uname)" = "Darwin" ]; then
     LOGIN_SHELL=$(finger $(id -u -n) | grep Shell | cut -d : -f 3)
     echo "macOS detected. User shell is:" $LOGIN_SHELL
-    if [ $LOGIN_SHELL == "/bin/zsh" ]; then 		# macOS moved to ZSH after macOS Catalina
+    if [ $LOGIN_SHELL = "/bin/zsh" ]; then 		# macOS moved to ZSH after macOS Catalina
       update_profile "$HOME/.zshrc"
     else
       update_profile "$HOME/.profile" || update_profile "$HOME/.bash_profile"


### PR DESCRIPTION
zsh wants "=" not "==" for test equality.
"=" also works in bash.
zsh is the default shell on MacOS, so it seems prudent to work by default on that platform.